### PR TITLE
feat(ui): add dark mode toggle

### DIFF
--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -23,11 +23,42 @@
 
         <div class="h-8 w-[1px] bg-gray-400 dark:bg-gray-500"></div>
 
-        <!-- TODO: theme toggle -->
-        <button class="flex h-8 w-8 items-center justify-center">
+        <button class="flex h-8 w-8 items-center justify-center" id="toggle-id">
           <i class="bx bx-moon text-xl"></i>
         </button>
       </div>
     </nav>
   </body>
 </html>
+
+<script is:inline>
+  const TOGGLE_ID = "toggle-id";
+  const INIT = "init";
+  const TOGGLE = "toggle";
+  const DARK = "dark";
+  const LIGHT = "light";
+
+  const button = document.getElementById(TOGGLE_ID);
+  const icon = button?.querySelector("i");
+  if (!button || !icon) throw new Error(`missing "#${TOGGLE_ID}" or its icon`);
+
+  const getValue = () =>
+    /** @type {DARK | LIGHT | undefined} */
+    (localStorage?.getItem(TOGGLE_ID)?.match(`^${DARK}|${LIGHT}$`)?.at(0));
+
+  /** @param {INIT | TOGGLE} action */
+  const setValue = (action) => {
+    const value = getValue() || (prefersDark.matches ? DARK : LIGHT);
+    const newValue = action === INIT ? value : value === DARK ? LIGHT : DARK;
+
+    document.documentElement.classList.toggle(DARK, newValue === DARK);
+    icon.className = `bx ${newValue === DARK ? "bx-sun" : "bx-moon"} text-xl`;
+    if (action === TOGGLE) localStorage?.setItem(TOGGLE_ID, newValue);
+  };
+
+  const prefersDark = matchMedia("(prefers-color-scheme: dark)");
+
+  prefersDark.addEventListener("change", () => !getValue() && setValue(INIT));
+  button.addEventListener("click", () => setValue(TOGGLE));
+  setValue(INIT);
+</script>

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -32,11 +32,9 @@ const { title } = Astro.props;
 </html>
 
 <style is:global>
-  @media (prefers-color-scheme: dark) {
-    .astro-code,
-    .astro-code span {
-      background-color: var(--shiki-dark-bg) !important;
-      color: var(--shiki-dark) !important;
-    }
+  .dark .astro-code,
+  .dark .astro-code span {
+    background-color: var(--shiki-dark-bg) !important;
+    color: var(--shiki-dark) !important;
   }
 </style>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -3,6 +3,7 @@ import typography from "@tailwindcss/typography";
 /** @type {import("tailwindcss").Config} */
 export default {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
+  darkMode: "selector",
   plugins: [typography],
   theme: {
     extend: {


### PR DESCRIPTION
implement a simple dark mode toggle in the navbar (loosely based on the
guide found in the astro docs, see:
https://www.kevinzunigacuellar.com/blog/dark-mode-in-astro/)